### PR TITLE
Fix profile PATH export in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN apk add --no-cache openjdk23-jre@testing
 RUN curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz | gzip -d > cs
 RUN chmod +x cs
 RUN ./cs setup --yes
-RUN echo "Export PATH=\"$PATH:/usr/lib/jvm/java-23-openjdk\"" > ~/.profile
+RUN echo 'export PATH="$PATH:/usr/lib/jvm/java-23-openjdk"' > ~/.profile
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## Summary
- fix `export PATH` command in Dockerfile to avoid expansion at build time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fbde361c8320a2446020e7bdd52f